### PR TITLE
Fix snap tmp folder

### DIFF
--- a/server/api/v1/ConsoleWsAPI.js
+++ b/server/api/v1/ConsoleWsAPI.js
@@ -11,6 +11,7 @@ const levelNames = {
 
 /**
  * Websockets API for the Inexor Console.
+ * @module api
  */
 class ConsoleWsAPI {
 

--- a/server/api/v1/FlexRestAPI.js
+++ b/server/api/v1/FlexRestAPI.js
@@ -8,6 +8,7 @@ const bunyan = require('bunyan'); // Since FlexServer sits on top of @inexorgame
 
 /**
  * REST API for managing Inexor Flex itself.
+ * @module api
  */
 class FlexRestAPI {
 

--- a/server/api/v1/InexorTreeRestAPI.js
+++ b/server/api/v1/InexorTreeRestAPI.js
@@ -2,6 +2,7 @@ const util = require('util');
 
 /**
  * REST API for managing tree nodes of the Inexor Tree.
+ * @module api
  */
 class InexorTreeRestAPI {
 

--- a/server/api/v1/InexorTreeWsAPI.js
+++ b/server/api/v1/InexorTreeWsAPI.js
@@ -10,6 +10,7 @@ const syncStates = {
 
 /**
  * Websockets API for managing tree nodes of the Inexor Tree.
+ * @module api
  */
 class InexorTreeWsAPI {
 

--- a/server/api/v1/InstancesRestAPI.js
+++ b/server/api/v1/InstancesRestAPI.js
@@ -3,6 +3,7 @@ const util = require('util');
 
 /**
  * REST API for managing instances of Inexor Core.
+ * @module api
  */
 class InstancesRestAPI extends EventEmitter {
 

--- a/server/api/v1/MediaRepositoryRestAPI.js
+++ b/server/api/v1/MediaRepositoryRestAPI.js
@@ -4,6 +4,7 @@ const inexor_path = require('@inexorgame/path');
 
 /**
  * REST API for media repositories.
+ * @module api
  */
 class MediaRepositoryRestAPI {
 

--- a/server/api/v1/ProfilesRestAPI.js
+++ b/server/api/v1/ProfilesRestAPI.js
@@ -5,6 +5,7 @@ const log = inexor_log('@inexorgame/flex/api/v1/profiles');
 
 /**
  * REST API for managing profiles.
+ * @module api
  */
 class ProfilesRestAPI {
 

--- a/server/api/v1/ReleasesRestAPI.js
+++ b/server/api/v1/ReleasesRestAPI.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events');
 
 /**
  * REST API for managing releases of Inexor Core.
+ * @module api
  */
 class ReleasesRestAPI extends EventEmitter {
 

--- a/server/util/logger/index.js
+++ b/server/util/logger/index.js
@@ -1,3 +1,6 @@
+/**
+ * @module logger
+ */
 const bunyan = require('bunyan');
 const bunyanDebugStream = require('bunyan-debug-stream');
 

--- a/server/util/path/index.js
+++ b/server/util/path/index.js
@@ -1,6 +1,5 @@
 /**
  * @module path
- * // TODO: Might be better called inexorgame/defaults
  */
 
 const process = require('process');

--- a/server/util/path/standardpaths.js
+++ b/server/util/path/standardpaths.js
@@ -21,8 +21,8 @@ if (process.env.SNAP_USER_DATA) {
   homeDir = process.env.SNAP_USER_DATA;
 }
 
-if (process.env.SNAP_COMMON) {
-  tmpDir = process.env.SNAP_COMMON;
+if (process.env.SNAP_USER_COMMON) {
+  tmpDir = process.env.SNAP_USER_COMMON;
 }
 
 /**

--- a/src/context/README.md
+++ b/src/context/README.md
@@ -1,0 +1,51 @@
+context
+-------
+
+This package is vivid for the functionality of Inexor Flex.
+It glues together packages with the following flow
+
+- each component has a an `ApplicationContext`
+- the `ApplicationContext` is used to register necessary dependencies
+- there is a "after initialization" hook, that is used as a asynchronous replacement for the constructor
+
+## Module template
+A module using the `ApplicationContext` should look as follows
+
+```
+class Module {
+
+    /**
+     * @constructor
+     */
+    constructor(applicationContext) {
+        super();
+
+        // Here you can do things like initalizing internal states
+        this.initialized = true;
+    }
+
+    /**
+     * Sets the dependencies from the application context.
+     * @function
+     */
+    setDependencies() {
+        /// The Inexor Tree root node
+        this.root = this.applicationContext.get('tree');
+
+        /// The router of the Inexor Flex webserver
+        this.router = this.applicationContext.get('router');
+
+        /// The Inexor Tree node containing your module nodes
+        this.releaseManagerTreeNode = this.root.getOrCreateNode('module');
+    }
+
+    /**
+     * Initialization after the components in the application context have been
+     * constructed.
+     * @function
+     */
+    afterPropertiesSet() {
+        // Do something fancy after the framework has been initalized
+    }
+}
+```

--- a/src/instances/Connector.js
+++ b/src/instances/Connector.js
@@ -1,6 +1,6 @@
 /**
  * This module provides a connector to Inexor Core instances.
- * @module connector
+ * @module instances
  * @see grpc
  */
 

--- a/src/interfaces/WebUserInterfaceManager.js
+++ b/src/interfaces/WebUserInterfaceManager.js
@@ -15,6 +15,7 @@ const log = require('@inexorgame/logger')();
 
 /**
  * Management service for web user interfaces.
+ * @module interfaces
  */
 class WebUserInterfaceManager extends EventEmitter {
 

--- a/src/media/Media.js
+++ b/src/media/Media.js
@@ -3,6 +3,7 @@ const EventEmitter = require('events');
 
 /**
  * The media types.
+ * @module media
  */
 const media_types = [
   'map',

--- a/src/media/Repository.js
+++ b/src/media/Repository.js
@@ -10,6 +10,7 @@ const inexor_path = require('@inexorgame/path');
 /**
  * The media repository types.
  * Future types may be 'http+rest', 'mongo'
+ * @module media
  */
 const repository_types = [
   'fs',

--- a/src/releases/ReleaseManager.js
+++ b/src/releases/ReleaseManager.js
@@ -15,6 +15,9 @@ const inexor_path = require('@inexorgame/path');
 // It won't let us use a custom API agent, take IE5 than
 const userAgent = 'Mozilla/4.0 (compatible; MSIE 5.0b1; Mac_PowerPC)';
 
+/**
+ * @module releases
+ */
 
 class ReleaseManager extends EventEmitter {
 

--- a/src/tree/Node.js
+++ b/src/tree/Node.js
@@ -4,6 +4,7 @@ const util = require('./util')
 
 /**
  * Represents a tree Node
+ * @module tree
  * @todo Add a verbose logging system (shouldn't be difficult though)
  */
 class Node extends EventEmitter {

--- a/src/tree/Root.js
+++ b/src/tree/Root.js
@@ -3,6 +3,7 @@ const util = require('./util')
 
 /**
  * Represents the inexor root tree
+ * @module tree
  */
 class Root extends Node {
     /**

--- a/src/tree/util.js
+++ b/src/tree/util.js
@@ -1,4 +1,8 @@
 /**
+ * @module tree
+ */
+
+/**
  * @property {string} separator - the tree seperator, usually "/"
  */
 const separator = '/';

--- a/src/treeclient/TreeClient.js
+++ b/src/treeclient/TreeClient.js
@@ -3,6 +3,7 @@ const log = require('@inexorgame/logger')();
 
 /**
  * The client for the local or remote Inexor Tree instances via a REST API.
+ * @module treeclient
  * @see {@link https://www.npmjs.com/package/node-rest-client}
  */
 class TreeClient {


### PR DESCRIPTION
This PR fixes the snap package

- the `SNAP_USER_COMMON` folder is used for `tmp`. Benefit: no `sudo` privileges needed any more
- also few doc improvements have been added
